### PR TITLE
Objects via solr

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ formats. To enable custom paths for specific content models, first enable the de
 
 Aliases can include the object's pid (`[fedora:pid]`), the Fedora label (`[fedora:label]`), the namespace (`[fedora:namespace]`), and/or the pid without the namespace (`[fedora:shortpid]`). See the documentation for [Pathauto](https://www.drupal.org/documentation/modules/pathauto) for more information on creating aliases, and read the FAQ below.
 
+When creating aliases in batch, Islandora Pathauto will default to using a Sparql query to the Triple Store. This can be changed to using Solr, with the added advantage that it is possible to specify the base Solr query, which can be useful in case of multisites.
+
 ## Documentation
 
 Further documentation for this module is available at [our wiki](https://wiki.duraspace.org/display/ISLANDORA/Islandora+Pathauto).

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -79,7 +79,7 @@ function islandora_pathauto_admin_settings(array $form, array &$form_state) {
     '#states' => array(
       'visible' => array('input[name=objects_query_method]' => array('value' => 'solr')),
     ),
-    '#default_value' => variable_get('islandora_pathauto_query_solr', '*:*'),
+    '#default_value' => variable_get('islandora_pathauto_objects_query_solr', '*:*'),
   );
 
   $form['use_cron'] = array(

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -63,18 +63,21 @@ function islandora_pathauto_admin_settings(array $form, array &$form_state) {
   if (module_exists('islandora_solr')) {
     $options['solr'] = t('Solr');
   }
-  $form['objects_query_method'] = array(
-    '#type' => 'radios',
+  $form['objects_query'] = array(
+    '#type' => 'fieldset',
     '#title' => t('Objects Query Method'),
+  );
+  $form['objects_query']['objects_query_method'] = array(
+    '#type' => 'radios',
     '#options' => $options,
     '#default_value' => variable_get('islandora_pathauto_objects_query_method', 'sparql'),
   );
-  $form['objects_query_solr'] = array(
-    '#type' => 'fieldset',
+  $form['objects_query']['objects_query_solr'] = array(
+    '#type' => 'textfield',
     '#title' => t('Solr query'),
-    '#description' => t('The Solr query to use to find all objects. In most cases *:* is good, but for multisites you may want to filter by a special ancestors_ms field.'),
+    '#description' => t('The Solr query to use to find all objects. In most cases *:* is good, but for multisites you may want to filter by ancestors_ms:"root_collection_id".'),
     '#states' => array(
-      'visible' => array('input[name=objects_query]' => array('value' => 'solr')),
+      'visible' => array('input[name=objects_query_method]' => array('value' => 'solr')),
     ),
     '#default_value' => variable_get('islandora_pathauto_query_solr', '*:*'),
   );

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -59,6 +59,26 @@ function islandora_pathauto_admin_settings(array $form, array &$form_state) {
     '#default_value' => $already_chosen,
   );
 
+  $options = array('sparql' => t('Sparql'));
+  if (module_exists('islandora_solr')) {
+    $options['solr'] = t('Solr');
+  }
+  $form['objects_query_method'] = array(
+    '#type' => 'radios',
+    '#title' => t('Objects Query Method'),
+    '#options' => $options,
+    '#default_value' => variable_get('islandora_pathauto_objects_query_method', 'sparql'),
+  );
+  $form['objects_query_solr'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Solr query'),
+    '#description' => t('The Solr query to use to find all objects. In most cases *:* is good, but for multisites you may want to filter by a special ancestors_ms field.'),
+    '#states' => array(
+      'visible' => array('input[name=objects_query]' => array('value' => 'solr')),
+    ),
+    '#default_value' => variable_get('islandora_pathauto_query_solr', '*:*'),
+  );
+
   $form['use_cron'] = array(
     '#type' => 'checkbox',
     '#title' => t('Use cron to automatically add / update aliases.'),
@@ -84,6 +104,8 @@ function islandora_pathauto_admin_settings_submit($form, &$form_state) {
   $enabled = array_filter($form_state['values']['pathauto_table']['enabled']);
   variable_set('islandora_pathauto_selected_cmodels', array_keys($enabled));
   variable_set('islandora_pathauto_use_cron', $form_state['values']['use_cron']);
+  variable_set('islandora_pathauto_objects_query_method', $form_state['values']['objects_query_method']);
+  variable_set('islandora_pathauto_objects_query_solr', $form_state['values']['objects_query_solr']);
 }
 
 /**

--- a/islandora_pathauto.drush.inc
+++ b/islandora_pathauto.drush.inc
@@ -42,7 +42,10 @@ function drush_islandora_pathauto_islandora_aliases_complete() {
   $isdryrun = drush_get_option('dryrun');
   $fromdate = drush_get_option('fromdate');
   if ($fromdate === 'last') {
-    $fromdate = variable_get('islandora_pathauto_aliases_complete_drush', '1900-01-01');
+    $fromdate = variable_get('islandora_pathauto_aliases_complete_last_date', '1900-01-01');
+  }
+  if (preg_match('/^[12][0-9]{3}-[01][0-9]-[0-3][0-9]$/', $fromdate) === 1) {
+    $fromdate = $fromdate . 'T00:00:00.000Z';
   }
 
   batch_set(array(
@@ -73,22 +76,24 @@ function islandora_pathauto_bulk_batch_process_via_drush($fromdate = NULL, $isdr
   }
   islandora_pathauto_bulk_batch_process_from_date($fromdate, $context);
 
-  $sandbox = $context['sandbox'];
-  if (isset($sandbox['warning'])) {
-    drush_log($sandbox['warning'], 'warning');
-  }
-  $checked = $sandbox['total_processed'];
-  $added = $sandbox['total_alias'];
-  $firstcreationdate = $sandbox['firstcd'];
-  $lastcreationdate = $sandbox['cd'];
-  drush_log(t("Checked !checked objects between @first and @last, !verb !added aliases.", array(
-    '!checked' => $checked,
-    '!added' => $added,
-    '!verb' => $isdryrun?"missing":"added",
-    '@first' => $firstcreationdate,
-    '@last' => $lastcreationdate,
-  )), "success");
-  if (!$isdryrun) {
-    variable_set('islandora_pathauto_aliases_complete_last_date', $lastcreationdate);
+  if ($context['finished'] === 1) {
+    $sandbox = $context['sandbox'];
+    if (isset($sandbox['warning'])) {
+      drush_log($sandbox['warning'], 'warning');
+    }
+    $checked = $sandbox['total_processed'];
+    $added = $sandbox['total_alias'];
+    $firstcreationdate = $sandbox['firstcd'];
+    $lastcreationdate = $sandbox['cd'];
+    drush_log(t("Checked !checked objects between @first and @last, !verb !added aliases.", array(
+      '!checked' => $checked,
+      '!added' => $added,
+      '!verb' => $isdryrun?"missing":"added",
+      '@first' => $firstcreationdate,
+      '@last' => $lastcreationdate,
+    )), "success");
+    if (!$isdryrun) {
+      variable_set('islandora_pathauto_aliases_complete_last_date', $lastcreationdate);
+    }
   }
 }

--- a/islandora_pathauto.drush.inc
+++ b/islandora_pathauto.drush.inc
@@ -48,7 +48,7 @@ function drush_islandora_pathauto_islandora_aliases_complete() {
   batch_set(array(
     'title' => t('Islandora Pathauto cron bulk updating URL aliases'),
     'operations' => array(
-      array('islandora_pathauto_bulk_batch_process_via_drush', array($fromdate)),
+      array('islandora_pathauto_bulk_batch_process_via_drush', array($fromdate, $isdryrun)),
     ),
   ));
 
@@ -67,11 +67,28 @@ function drush_islandora_pathauto_islandora_aliases_complete() {
  * @param array $context
  *   Batch context.
  */
-function islandora_pathauto_bulk_batch_process_via_drush($fromdate, &$context = array()) {
+function islandora_pathauto_bulk_batch_process_via_drush($fromdate = NULL, $isdryrun = FALSE, &$context = array()) {
+  if ($isdryrun) {
+    $context['dryrun'] = TRUE;
+  }
   islandora_pathauto_bulk_batch_process_from_date($fromdate, $context);
 
   $sandbox = $context['sandbox'];
   if (isset($sandbox['warning'])) {
     drush_log($sandbox['warning'], 'warning');
+  }
+  $checked = $sandbox['total_processed'];
+  $added = $sandbox['total_alias'];
+  $firstcreationdate = $sandbox['firstcd'];
+  $lastcreationdate = $sandbox['cd'];
+  drush_log(t("Checked !checked objects between @first and @last, !verb !added aliases.", array(
+    '!checked' => $checked,
+    '!added' => $added,
+    '!verb' => $isdryrun?"missing":"added",
+    '@first' => $firstcreationdate,
+    '@last' => $lastcreationdate,
+  )), "success");
+  if (!$isdryrun) {
+    variable_set('islandora_pathauto_aliases_complete_last_date', $lastcreationdate);
   }
 }

--- a/islandora_pathauto.drush.inc
+++ b/islandora_pathauto.drush.inc
@@ -74,7 +74,4 @@ function islandora_pathauto_bulk_batch_process_via_drush($fromdate, &$context = 
   if (isset($sandbox['warning'])) {
     drush_log($sandbox['warning'], 'warning');
   }
-  if ($context['finished'] == 1) {
-    drush_log(t('Added @total_alias aliases on @total_processed PIDs.', array('@total_alias' => $sandbox['total_alias'], '@total_processed' => $sandbox['total_processed'])), 'ok');
-  }
 }

--- a/islandora_pathauto.drush.inc
+++ b/islandora_pathauto.drush.inc
@@ -42,126 +42,39 @@ function drush_islandora_pathauto_islandora_aliases_complete() {
   $isdryrun = drush_get_option('dryrun');
   $fromdate = drush_get_option('fromdate');
   if ($fromdate === 'last') {
-    $fromdate = variable_get('islandora_pathauto_aliases_complete_last_date', '1900-01-01');
-  }
-  $settings = islandora_pathauto_pathauto('settings');
-  $pattern_all_objects = variable_get('pathauto_' . $settings->module . '_pattern', $settings->patterndefault);
-  // Determine what content models have a pattern and
-  // only query objects with those particular models.
-  if (isset($settings->patternitems)) {
-    foreach ($settings->patternitems as $model => $label) {
-      $pattern = variable_get('pathauto_' . $settings->module . '_' . $model . '_pattern', '');
-      if (!empty($pattern)) {
-        $models[] = $model;
-      }
-    }
-  }
-  if (empty($models)) {
-    $models[] = 'fedora-system:FedoraObject-3.0';
+    $fromdate = variable_get('islandora_pathauto_aliases_complete_drush', '1900-01-01');
   }
 
-  foreach ($models as &$filter) {
-    $filter = "sameTerm(?model, <info:fedora/$filter>)";
-  }
-  $filters['model'] = format_string('FILTER(!models)', array('!models' => implode(' || ', $models)));
-  if (variable_get('islandora_namespace_restriction_enforced', FALSE)) {
-    $namespace_array = islandora_get_allowed_namespaces();
-    $namespace_sparql = implode('|', $namespace_array);
-    $filters['ns'] = format_string('FILTER(regex(str(?object), "info:fedora/(!namespaces):"))', array('!namespaces' => $namespace_sparql));
-  }
+  batch_set(array(
+    'title' => t('Islandora Pathauto cron bulk updating URL aliases'),
+    'operations' => array(
+      array('islandora_pathauto_bulk_batch_process_via_drush', array($fromdate)),
+    ),
+  ));
 
-  $query = <<<EOQ
-SELECT ?object ?cd ?title
-FROM <#ri>
-WHERE {
-  ?object <fedora-model:label> ?title ;
-  <info:fedora/fedora-system:def/model#createdDate> ?cd ;
-  <fedora-model:hasModel> ?model ;
-  <fedora-model:state> <fedora-model:Active> .
-  !filters
-}
-ORDER BY ?cd
-!limit
-EOQ;
-
-  drupal_static_reset('islandora_get_tuque_connection');
-  $tuque = islandora_get_tuque_connection();
-  if ($tuque) {
-    $firstcreationdate;
-    $lastcreationdate;
-    if (isset($fromdate)) {
-      $lastcreationdate = $fromdate;
-    }
-    $limit = 2500;
-    $checked = 0;
-    $added = 0;
-    $cycles = 0;
-
-    while (TRUE) {
-      $cycles++;
-      if (isset($lastcreationdate)) {
-        $filters['cd'] = "FILTER(?cd > '{$lastcreationdate}'^^xsd:dateTime)";
-      }
-      else {
-        $filters['cd'] = '';
-      }
-
-      $query_string = format_string($query, array(
-        '!filters' => implode(' ', $filters),
-        '!limit' => "LIMIT $limit"));
-      $results = $tuque->repository->ri->sparqlQuery($query_string);
-      if (empty($results)) {
-        break;
-      }
-      else {
-        foreach ($results as $result) {
-          $pid = $result['object']['value'];
-          if (!isset($firstcreationdate)) {
-            $firstcreationdate = $result['cd']['value'];
-          }
-          $lastcreationdate = $result['cd']['value'];
-
-          $source = "islandora/object/$pid";
-   
-          $checked++;
-
-          $result = db_query('SELECT a.source FROM url_alias a WHERE a.source LIKE :source',
-            array(':source' => $source));
-          $c = $result->rowCount();
-
-          if ($c == 0) {
-            if ($isdryrun) {
-              $added++;
-              drush_log("Should add alias for $source", "notice"); 
-            }
-            else {
-              //db_insert('url_alias')->fields(array('alias' => $alias, 'source' => $source, 'language' => 'und'))->execute();
-              $object = islandora_object_load($pid);
-              if ($object) {
-                $alias = islandora_pathauto_create_alias($object, 'bulkupdate');
-                if ($alias != "") {
-                  $added++;
-                }
-              }
-            }
-          }
-        }
-      }
-      if (($cycles % 50) === 0) {
-        drupal_static_reset('islandora_get_tuque_connection');
-        $tuque = islandora_get_tuque_connection();
-      }
-    }
-    drush_log(t("Checked !checked objects between @first and @last, !verb !added aliases.", array(
-      '!checked' => $checked,
-      '!added' => $added,
-      '!verb' => $isdryrun?"missing":"added",
-      '@first' => $firstcreationdate,
-      '@last' => $lastcreationdate,
-    )), "success");
-    if (!$isdryrun) {
-      variable_set('islandora_pathauto_aliases_complete_last_date', $lastcreationdate);
-    }
-  }
+  // This is a hack around the broken batch API.
+  // https://drupal.org/node/638712#comment-2289138
+  $batch =& batch_get();
+  $batch['progressive'] = FALSE;
+  drush_backend_batch_process();
 }
 
+/**
+ * Batch operation for generating aliases for Islandora objects via drush.
+ *
+ * @param bool $use_cron_last
+ *   Flag for using cron last time.
+ * @param array $context
+ *   Batch context.
+ */
+function islandora_pathauto_bulk_batch_process_via_drush($fromdate, &$context = array()) {
+  islandora_pathauto_bulk_batch_process_from_date($fromdate, $context);
+
+  $sandbox = $context['sandbox'];
+  if (isset($sandbox['warning'])) {
+    drush_log($sandbox['warning'], 'warning');
+  }
+  if ($context['finished'] == 1) {
+    drush_log(t('Added @total_alias aliases on @total_processed PIDs.', array('@total_alias' => $sandbox['total_alias'], '@total_processed' => $sandbox['total_processed'])), 'ok');
+  }
+}

--- a/islandora_pathauto.install
+++ b/islandora_pathauto.install
@@ -14,6 +14,8 @@ function islandora_pathauto_uninstall() {
   $variables = array(
     'islandora_pathauto_use_cron',
     'islandora_pathauto_selected_cmodels',
+    'islandora_pathauto_objects_query_method',
+    'islandora_pathauto_objects_query_solr',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -164,12 +164,6 @@ function islandora_pathauto_islandora_object_purged($pid) {
 function islandora_pathauto_bulk_batch_process($use_cron_last = FALSE, &$context = array()) {
   module_load_include('inc', 'islandora', 'includes/utilities');
   $sandbox = &$context['sandbox'];
-  $args = array(
-    '!filters' => '',
-    '!limit' => '',
-    '!md_name' => '',
-    '!md_field' => '',
-  );
   if (empty($sandbox)) {
     $sandbox['total'] = 0;
     $sandbox['total_alias'] = 0;
@@ -213,6 +207,12 @@ function islandora_pathauto_bulk_batch_process($use_cron_last = FALSE, &$context
 
 function islandora_pathauto_bulk_batch_process_sparql($use_cron_last = FALSE, &$context = array()) {
   $sandbox = &$context['sandbox'];
+  $args = array(
+    '!filters' => '',
+    '!limit' => '',
+    '!md_name' => '',
+    '!md_field' => '',
+  );
   if (empty($sandbox) || $sandbox['total_processed'] === 0) {
     $model_filters = $sandbox['models'];
     foreach ($model_filters as &$filter) {

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -198,7 +198,22 @@ function islandora_pathauto_bulk_batch_process($use_cron_last = FALSE, &$context
       $context['finished'] = 1;
       return;
     }
+  }
 
+  islandora_pathauto_bulk_batch_process_sparql($use_cron_last, $context);
+
+  $context['message'] = t('Processed @total_processed of @total. Added @total_alias aliases.', array(
+    '@total_processed' => $sandbox['total_processed'],
+    '@total_alias' => $sandbox['total_alias'],
+    '@total' => $sandbox['total']));
+  if ($context['finished'] == 1) {
+    drupal_set_message(t('Added @total_alias aliases on @total_processed PIDs.', array('@total_alias' => $sandbox['total_alias'], '@total_processed' => $sandbox['total_processed'])));
+  }
+}
+
+function islandora_pathauto_bulk_batch_process_sparql($use_cron_last = FALSE, &$context = array()) {
+  $sandbox = &$context['sandbox'];
+  if (empty($sandbox) || $sandbox['total_processed'] === 0) {
     $model_filters = $sandbox['models'];
     foreach ($model_filters as &$filter) {
       $filter = "sameTerm(?model, <info:fedora/$filter>)";
@@ -278,13 +293,6 @@ EOQ;
         }
       }
     }
-  }
-  $context['message'] = t('Processed @total_processed of @total. Added @total_alias aliases.', array(
-    '@total_processed' => $sandbox['total_processed'],
-    '@total_alias' => $sandbox['total_alias'],
-    '@total' => $sandbox['total']));
-  if ($context['finished'] == 1) {
-    drupal_set_message(t('Added @total_alias aliases on @total_processed PIDs.', array('@total_alias' => $sandbox['total_alias'], '@total_processed' => $sandbox['total_processed'])));
   }
 }
 

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -194,7 +194,7 @@ function islandora_pathauto_bulk_batch_process($use_cron_last = FALSE, &$context
     }
   }
 
-  islandora_pathauto_bulk_batch_process_sparql($use_cron_last, $context);
+  islandora_pathauto_bulk_batch_process_solr($use_cron_last, $context);
 
   $context['message'] = t('Processed @total_processed of @total. Added @total_alias aliases.', array(
     '@total_processed' => $sandbox['total_processed'],
@@ -299,6 +299,75 @@ EOQ;
             $sandbox['total_alias']++;
           }
         }
+      }
+    }
+  }
+}
+
+/**
+ * Batch operation for generating aliases for Islandora objects via Solr.
+ *
+ * @param bool $use_cron_last
+ *   Flag for using cron last time.
+ * @param array $context
+ *   Batch context.
+ */
+function islandora_pathauto_bulk_batch_process_solr($use_cron_last = FALSE, &$context = array()) {
+  $sandbox = &$context['sandbox'];
+
+  $lastmodfield = "fgs_lastModifiedDate_dt";
+  $solrquery = "*:*";
+  $qp = new IslandoraSolrQueryProcessor();
+  $qp->buildQuery($solrquery);
+  $qp->solrLimit = 50;
+  $qp->solrStart = $sandbox['total_processed'];
+  $qp->solrParams['fq'] = array();
+  $qp->solrParams['sort'] = "$lastmodfield ASC";
+  $qp->solrParams['fl'] = 'PID';
+
+  $cmf = variable_get('islandora_solr_content_model_field', 'RELS_EXT_hasModel_uri_ms');
+  $model_filters = $sandbox['models'];
+  foreach ($model_filters as $model) {
+    $qp->solrParams['fq'][] = $cmf . ':("' . $model . '" OR "info:fedora/' . $model . '"))';
+  }
+  if (variable_get('islandora_namespace_restriction_enforced', FALSE)) {
+    $namespace_map = function ($namespace) {
+      return 'PID:' . Apache_Solr_Service::escape("$namespace:") . '*';
+    };
+    $qp->solrParams['fq'][] = implode(' OR ', array_map($namespace_map, islandora_get_allowed_namespaces()));
+  }
+
+  if ($use_cron_last) {
+    $cronlastdate = gmdate("Y-m-d\TH:i:s.000\Z", variable_get('cron_last'));
+    $qp->solrParams['fq'][] = "$lastmodfield:[$cronlastdate TO *]";
+  }
+
+  $qp->executeQuery(FALSE);
+  $r = $qp->islandoraSolrResult;
+  $numfound = $r['response']['numFound'];
+  if ($numfound == 0) {
+    $context['finished'] = 1;
+    drupal_set_message(t('No objects found for selected models (@models).', array('@models' => implode(', ', $sandbox['models']))));
+    return t('No objects found.');
+  }
+  $context['total'] = $numfound;
+  $len = count($r['response']['objects']);
+  if ($len === 0) {
+    $context['finished'] = 1;
+  }
+  else {
+    $context['finished'] = $sandbox['total_processed'] / $sandbox['total'];
+  }
+  $sandbox['total_processed'] += $len;
+  for ($i = 0; $i < $len; $i++) {
+    $solrobj = $r['response']['objects'][$i];
+    $pid = $solrobj['PID'];
+    $sandbox['pid'] = $pid;
+    $object = islandora_object_load($pid);
+    if ($object) {
+      $alias = islandora_pathauto_create_alias($object, 'bulkupdate');
+      if ($alias != "") {
+        $sandbox['total_alias']++;
       }
     }
   }

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -328,7 +328,9 @@ function islandora_pathauto_bulk_batch_process_solr($use_cron_last = FALSE, &$co
   $cmf = variable_get('islandora_solr_content_model_field', 'RELS_EXT_hasModel_uri_ms');
   $model_filters = $sandbox['models'];
   foreach ($model_filters as $model) {
-    $qp->solrParams['fq'][] = $cmf . ':("' . $model . '" OR "info:fedora/' . $model . '"))';
+    if ($model !== 'fedora-system:FedoraObject-3.0') {
+      $qp->solrParams['fq'][] = $cmf . ':("' . $model . '" OR "info:fedora/' . $model . '")';
+    }
   }
   if (variable_get('islandora_namespace_restriction_enforced', FALSE)) {
     $namespace_map = function ($namespace) {

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -326,7 +326,7 @@ function islandora_pathauto_bulk_batch_process_solr($use_cron_last = FALSE, &$co
   $solrquery = variable_get('islandora_pathauto_objects_query_solr', '*:*');
   $qp = new IslandoraSolrQueryProcessor();
   $qp->buildQuery($solrquery);
-  $qp->solrLimit = 50;
+  $qp->solrLimit = 100;
   $qp->solrStart = $sandbox['total_processed'];
   $qp->solrParams['fq'] = array();
   $qp->solrParams['sort'] = "$lastmodfield ASC";

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -166,7 +166,7 @@ function islandora_pathauto_bulk_batch_process($use_cron_last = FALSE, &$context
   if ($use_cron_last) {
     $fromdate = gmdate("Y-m-d\TH:i:s\Z", variable_get('cron_last'));
   }
-  islandora_pathauto_bulk_batch_process_from_date($fromdate, &$context = array());
+  islandora_pathauto_bulk_batch_process_from_date($fromdate, $context);
 
   $sandbox = $context['sandbox'];
   if (isset($sandbox['warning'])) {

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -322,12 +322,24 @@ EOQ;
       foreach ($results as $result) {
         $pid = $result['object']['value'];
         $sandbox['cd'] = $result['cd']['value'];
+        if (!isset($sandbox['firstcd'])) {
+          $sandbox['firstcd'] = $sandbox['cd'];
+        }
         $sandbox['pid'] = $pid;
-        $object = islandora_object_load($pid);
-        if ($object) {
-          $alias = islandora_pathauto_create_alias($object, 'bulkupdate');
-          if ($alias != "") {
+        if (isset($context['dryrun']) && $context['dryrun']) {
+          $path = "islandora/object/$pid";
+          $alias = drupal_lookup_path('alias', $path);
+          if ($alias !== FALSE && $alias !== $path) {
             $sandbox['total_alias']++;
+          }
+        }
+        else {
+          $object = islandora_object_load($pid);
+          if ($object) {
+            $alias = islandora_pathauto_create_alias($object, 'bulkupdate');
+            if ($alias != "") {
+              $sandbox['total_alias']++;
+            }
           }
         }
       }
@@ -357,7 +369,7 @@ function islandora_pathauto_bulk_batch_process_from_date_solr($fromdate = NULL, 
   $qp->solrStart = $sandbox['total_processed'];
   $qp->solrParams['fq'] = array();
   $qp->solrParams['sort'] = "$lastmodfield ASC";
-  $qp->solrParams['fl'] = 'PID';
+  $qp->solrParams['fl'] = "PID $lastmodfield";
 
   $cmf = variable_get('islandora_solr_content_model_field', 'RELS_EXT_hasModel_uri_ms');
   $model_filters = $sandbox['models'];
@@ -397,12 +409,25 @@ function islandora_pathauto_bulk_batch_process_from_date_solr($fromdate = NULL, 
   for ($i = 0; $i < $len; $i++) {
     $solrobj = $r['response']['objects'][$i];
     $pid = $solrobj['PID'];
+    $sandbox['cd'] = $solrobj['solr_doc'][$lastmodfield];
+    if (!isset($sandbox['firstcd'])) {
+      $sandbox['firstcd'] = $sandbox['cd'];
+    }
     $sandbox['pid'] = $pid;
-    $object = islandora_object_load($pid);
-    if ($object) {
-      $alias = islandora_pathauto_create_alias($object, 'bulkupdate');
-      if ($alias != "") {
+    if (isset($context['dryrun']) && $context['dryrun']) {
+      $path = "islandora/object/$pid";
+      $alias = drupal_lookup_path('alias', $path);
+      if ($alias !== FALSE && $alias !== $path) {
         $sandbox['total_alias']++;
+      }
+    }
+    else {
+      $object = islandora_object_load($pid);
+      if ($object) {
+        $alias = islandora_pathauto_create_alias($object, 'bulkupdate');
+        if ($alias != "") {
+          $sandbox['total_alias']++;
+        }
       }
     }
   }

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -347,7 +347,7 @@ function islandora_pathauto_bulk_batch_process_solr($use_cron_last = FALSE, &$co
   }
 
   if ($use_cron_last) {
-    $cronlastdate = gmdate("Y-m-d\TH:i:s.000\Z", variable_get('cron_last'));
+    $cronlastdate = gmdate("Y-m-d\TH:i:s\Z", variable_get('cron_last'));
     $qp->solrParams['fq'][] = "$lastmodfield:[$cronlastdate TO *]";
   }
 

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -352,7 +352,7 @@ function islandora_pathauto_bulk_batch_process_solr($use_cron_last = FALSE, &$co
     drupal_set_message(t('No objects found for selected models (@models).', array('@models' => implode(', ', $sandbox['models']))));
     return t('No objects found.');
   }
-  $context['total'] = $numfound;
+  $sandbox['total'] = $numfound;
   $len = count($r['response']['objects']);
   if ($len === 0) {
     $context['finished'] = 1;

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -329,7 +329,7 @@ EOQ;
         if (isset($context['dryrun']) && $context['dryrun']) {
           $path = "islandora/object/$pid";
           $alias = drupal_lookup_path('alias', $path);
-          if ($alias !== FALSE && $alias !== $path) {
+          if ($alias === FALSE || $alias === $path) {
             $sandbox['total_alias']++;
           }
         }
@@ -417,7 +417,7 @@ function islandora_pathauto_bulk_batch_process_from_date_solr($fromdate = NULL, 
     if (isset($context['dryrun']) && $context['dryrun']) {
       $path = "islandora/object/$pid";
       $alias = drupal_lookup_path('alias', $path);
-      if ($alias !== FALSE && $alias !== $path) {
+      if ($alias === FALSE || $alias === $path) {
         $sandbox['total_alias']++;
       }
     }

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -205,6 +205,14 @@ function islandora_pathauto_bulk_batch_process($use_cron_last = FALSE, &$context
   }
 }
 
+/**
+ * Batch operation for generating aliases for Islandora objects via Sparql.
+ *
+ * @param bool $use_cron_last
+ *   Flag for using cron last time.
+ * @param array $context
+ *   Batch context.
+ */
 function islandora_pathauto_bulk_batch_process_sparql($use_cron_last = FALSE, &$context = array()) {
   $sandbox = &$context['sandbox'];
   $args = array(

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -334,7 +334,7 @@ function islandora_pathauto_bulk_batch_process_solr($use_cron_last = FALSE, &$co
   }
   if (variable_get('islandora_namespace_restriction_enforced', FALSE)) {
     $namespace_map = function ($namespace) {
-      return 'PID:' . Apache_Solr_Service::escape("$namespace:") . '*';
+      return 'PID:' . islandora_solr_lesser_escape("$namespace:") . '*';
     };
     $qp->solrParams['fq'][] = implode(' OR ', array_map($namespace_map, islandora_get_allowed_namespaces()));
   }

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -194,7 +194,12 @@ function islandora_pathauto_bulk_batch_process($use_cron_last = FALSE, &$context
     }
   }
 
-  islandora_pathauto_bulk_batch_process_solr($use_cron_last, $context);
+  if (variable_get('islandora_pathauto_objects_query_method', 'sparql') === 'solr') {
+    islandora_pathauto_bulk_batch_process_solr($use_cron_last, $context);
+  }
+  else {
+    islandora_pathauto_bulk_batch_process_sparql($use_cron_last, $context);
+  }
 
   $context['message'] = t('Processed @total_processed of @total. Added @total_alias aliases.', array(
     '@total_processed' => $sandbox['total_processed'],
@@ -313,10 +318,12 @@ EOQ;
  *   Batch context.
  */
 function islandora_pathauto_bulk_batch_process_solr($use_cron_last = FALSE, &$context = array()) {
+  module_load_include('inc', 'islandora_solr', 'includes/utilities');
+
   $sandbox = &$context['sandbox'];
 
   $lastmodfield = "fgs_lastModifiedDate_dt";
-  $solrquery = "*:*";
+  $solrquery = variable_get('islandora_pathauto_objects_query_solr', '*:*');
   $qp = new IslandoraSolrQueryProcessor();
   $qp->buildQuery($solrquery);
   $qp->solrLimit = 50;

--- a/islandora_pathauto.module
+++ b/islandora_pathauto.module
@@ -162,6 +162,30 @@ function islandora_pathauto_islandora_object_purged($pid) {
  *   Batch context.
  */
 function islandora_pathauto_bulk_batch_process($use_cron_last = FALSE, &$context = array()) {
+  $fromdate = NULL;
+  if ($use_cron_last) {
+    $fromdate = gmdate("Y-m-d\TH:i:s\Z", variable_get('cron_last'));
+  }
+  islandora_pathauto_bulk_batch_process_from_date($fromdate, &$context = array());
+
+  $sandbox = $context['sandbox'];
+  if (isset($sandbox['warning'])) {
+    drupal_set_message($sandbox['warning'], 'warning');
+  }
+  if ($context['finished'] == 1) {
+    drupal_set_message(t('Added @total_alias aliases on @total_processed PIDs.', array('@total_alias' => $sandbox['total_alias'], '@total_processed' => $sandbox['total_processed'])));
+  }
+}
+
+/**
+ * Batch operation for generating aliases for Islandora objects.
+ *
+ * @param string $fromdate
+ *   Process only objects that have a modification date greater than this date.
+ * @param array $context
+ *   Batch context.
+ */
+function islandora_pathauto_bulk_batch_process_from_date($fromdate = NULL, &$context = array()) {
   module_load_include('inc', 'islandora', 'includes/utilities');
   $sandbox = &$context['sandbox'];
   if (empty($sandbox)) {
@@ -188,37 +212,36 @@ function islandora_pathauto_bulk_batch_process($use_cron_last = FALSE, &$context
     }
 
     if (empty($sandbox['models'])) {
-      drupal_set_message(t('No patterns exist for Islandora objects.'), 'warning');
+      $sandbox['warning'] = t('No patterns exist for Islandora objects.');
       $context['finished'] = 1;
       return;
     }
   }
 
   if (variable_get('islandora_pathauto_objects_query_method', 'sparql') === 'solr') {
-    islandora_pathauto_bulk_batch_process_solr($use_cron_last, $context);
+    islandora_pathauto_bulk_batch_process_from_date_solr($fromdate, $context);
   }
   else {
-    islandora_pathauto_bulk_batch_process_sparql($use_cron_last, $context);
+    islandora_pathauto_bulk_batch_process_from_date_sparql($fromdate, $context);
   }
 
   $context['message'] = t('Processed @total_processed of @total. Added @total_alias aliases.', array(
     '@total_processed' => $sandbox['total_processed'],
     '@total_alias' => $sandbox['total_alias'],
     '@total' => $sandbox['total']));
-  if ($context['finished'] == 1) {
-    drupal_set_message(t('Added @total_alias aliases on @total_processed PIDs.', array('@total_alias' => $sandbox['total_alias'], '@total_processed' => $sandbox['total_processed'])));
-  }
 }
 
 /**
  * Batch operation for generating aliases for Islandora objects via Sparql.
  *
- * @param bool $use_cron_last
- *   Flag for using cron last time.
+ * @param string $fromdate
+ *   Process only objects that have a modification date greater than this date,
+ *   formatted as YYYY-MM-DD'T'hh:mm:ss'Z', e.g. 2020-05-14T23:59:59Z.
  * @param array $context
  *   Batch context.
  */
-function islandora_pathauto_bulk_batch_process_sparql($use_cron_last = FALSE, &$context = array()) {
+function islandora_pathauto_bulk_batch_process_from_date_sparql($fromdate = NULL, &$context = array()) {
+  $batchsize = 50;
   $sandbox = &$context['sandbox'];
   $args = array(
     '!filters' => '',
@@ -239,12 +262,11 @@ function islandora_pathauto_bulk_batch_process_sparql($use_cron_last = FALSE, &$
     }
   }
 
-  if ($use_cron_last) {
+  if ($fromdate !== NULL) {
     $args['!md_name'] = '?md';
     $args['!md_field'] = '<info:fedora/fedora-system:def/view#lastModifiedDate> ?md ;';
     if (!isset($sandbox['filters']['cron_last'])) {
-      $modified_date_time = gmdate("Y-m-d\TH:i:s\Z", variable_get('cron_last'));
-      $sandbox['filters']['cron_last'] = "FILTER(?md > '{$modified_date_time}'^^xsd:dateTime)";
+      $sandbox['filters']['cron_last'] = "FILTER(?md > '{$fromdate}'^^xsd:dateTime)";
     }
   }
 
@@ -263,6 +285,10 @@ ORDER BY ?cd
 !limit
 EOQ;
 
+  if ($sandbox['total_processed'] % ($batchsize * 50) === 0) {
+    // Reset tuque connection to solve memory problem.
+    drupal_static_reset('islandora_get_tuque_connection');
+  }
   $tuque = islandora_get_tuque_connection();
   if ($tuque) {
     $context['finished'] = 0;
@@ -284,7 +310,7 @@ EOQ;
     }
 
     $args['!filters'] = implode(' ', $sandbox['filters']);
-    $args['!limit'] = "LIMIT 50";
+    $args['!limit'] = "LIMIT $batchsize";
     $query_string = format_string($query, $args);
 
     $results = $tuque->repository->ri->sparqlQuery($query_string);
@@ -312,12 +338,13 @@ EOQ;
 /**
  * Batch operation for generating aliases for Islandora objects via Solr.
  *
- * @param bool $use_cron_last
- *   Flag for using cron last time.
+ * @param string $fromdate
+ *   Process only objects that have a modification date greater than this date,
+ *   formatted as YYYY-MM-DD'T'hh:mm:ss'Z', e.g. 2020-05-14T23:59:59Z.
  * @param array $context
  *   Batch context.
  */
-function islandora_pathauto_bulk_batch_process_solr($use_cron_last = FALSE, &$context = array()) {
+function islandora_pathauto_bulk_batch_process_from_date_solr($fromdate = NULL, &$context = array()) {
   module_load_include('inc', 'islandora_solr', 'includes/utilities');
 
   $sandbox = &$context['sandbox'];
@@ -346,9 +373,8 @@ function islandora_pathauto_bulk_batch_process_solr($use_cron_last = FALSE, &$co
     $qp->solrParams['fq'][] = implode(' OR ', array_map($namespace_map, islandora_get_allowed_namespaces()));
   }
 
-  if ($use_cron_last) {
-    $cronlastdate = gmdate("Y-m-d\TH:i:s\Z", variable_get('cron_last'));
-    $qp->solrParams['fq'][] = "$lastmodfield:[$cronlastdate TO *]";
+  if ($fromdate !== NULL) {
+    $qp->solrParams['fq'][] = "$lastmodfield:[$fromdate TO *]";
   }
 
   $qp->executeQuery(FALSE);


### PR DESCRIPTION
Add an option to use Solr for retrieving the object ids when using bulk generate.

In the admin form radio boxes are added to choose between using Sparql or Solr. This defaults to Sparql, just as it used to be. When selecting Solr the Solr query can be changed. It defaults to :, but for a multisite a more appropriate query can be given.
Two new configuration variables are added: islandora_pathauto_objects_query_method and islandora_pathauto_objects_query_solr.
The islandora_pathauto.module has been refactored so the Sparql related code is all in one function.